### PR TITLE
feat(release): use new plugin metadata updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           echo ::set-output name=PROJECT::$(basename `pwd`)
           echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=REPO::${GITHUB_REPOSITORY}
       - name: create release
         id: create_release
         uses: actions/create-release@v1
@@ -42,5 +43,11 @@ jobs:
           asset_name: ${{ steps.get_project_info.outputs.PROJECT }}-${{ steps.get_project_info.outputs.VERSION }}.zip
           asset_content_type: application/zip
       - name: add release to plugin repo
-        run: |
-          curl -XPOST -u "${{ secrets.USERNAME }}:${{ secrets.TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ExitoLab/examplePluginRepository/dispatches --data "{\"event_type\": \"onPluginRelease\", \"client_payload\": {\"org\": \"ExitoLab\", \"repo\": \"${{ steps.get_project_info.outputs.PROJECT }}\", \"released\": $(cat build/distributions/plugin-info.json)}}"
+        id: add-release
+        uses: armory-io/plugin-metadata-updater@master
+        env:
+          GITHUB_OAUTH: ${{ secrets.TOKEN }}
+        with:
+          metadata: build/distributions/plugin-info.json
+          binary_url: https://github.com/${{ steps.get_project_info.outputs.REPO }}/releases/download/${{ steps.get_project_info.outputs.VERSION }}/${{ steps.get_project_info.outputs.PROJECT }}-${{ steps.get_project_info.outputs.VERSION }}.zip
+          metadata_repo_url: https://github.com/exitolab/examplePluginRepository


### PR DESCRIPTION
I'm working towards removing the custom go code that's included in https://github.com/exitolab/examplePluginRepository. This code gets copied around every time someone wants to make a new plugin repository.

Instead I'm hoping everyone will use this GitHub action: https://github.com/armory-io/plugin-metadata-updater.

Two things will happen:

* The first time the GH action updates your metadata repo, the diff might be pretty big because the JSON format is slightly different (but better)
* It's going to create a PR, rather than just committing the update. If you don't like that, we can set up mergify to auto-merge the PRs.